### PR TITLE
feat: add game themed interface option

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -3,6 +3,12 @@ import { GameState, Card, Player } from '../types/game';
 import { Heart, Zap, Plus, Eye, RotateCcw, CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { CreateCardModal } from './CreateCardModal';
 import { DeckModal } from './DeckModal';
+import { useGameTheme } from '../hooks/useGameTheme';
+import { HUDHeader } from '../ui/HUDHeader';
+import { TurnWheel } from '../ui/TurnWheel';
+import { ChoiceButtons } from '../ui/ChoiceButtons';
+import { CardReveal } from '../ui/CardReveal';
+import { BottomBar } from '../ui/BottomBar';
 
 interface GameScreenProps {
   gameState: GameState;
@@ -46,6 +52,7 @@ export const GameScreen: React.FC<GameScreenProps> = ({
   onResetGame,
   onDrawNextPlayer,
 }) => {
+  const theme = useGameTheme();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDeckModal, setShowDeckModal] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -175,229 +182,294 @@ export const GameScreen: React.FC<GameScreenProps> = ({
     gameState.currentPlayerIndex !== null
       ? `Jogador ${gameState.currentPlayerIndex + 1} de ${gameState.players.length}`
       : `${gameState.players.length} jogadores na disputa`;
+  const boostPoints = currentPlayer?.boostPoints ?? 0;
 
   const drawHighlightText = finalDrawName ?? highlightedName ?? 'Girando nomes...';
   const drawStatusText = finalDrawName ? 'Próximo jogador definido!' : 'Girando nomes...';
 
-  return (
-    <div className="flex flex-1 justify-center px-4 py-10 sm:px-6 lg:px-8">
-      <div className="w-full max-w-5xl space-y-8">
-        <header className="rounded-card border border-border/60 bg-bg-800/80 p-6 shadow-heat [--focus-shadow:var(--shadow-heat)] backdrop-blur-xl">
-          <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-3">
-              <span className="text-xs font-semibold uppercase tracking-[0.4em] text-text-subtle">
-                Vez de jogar
-              </span>
-              <h2 className="text-4xl sm:text-5xl font-display uppercase tracking-[0.18em] text-text">
-                {playerNameDisplay}
-              </h2>
-              <div className="flex flex-wrap items-center gap-3 text-sm text-text-subtle">
-                <span className="inline-flex items-center gap-2 rounded-pill border border-border/50 bg-bg-900/60 px-4 py-1">
-                  <Zap size={16} />
-                  {playerBoostLabel}
-                </span>
-                <span
-                  className={`inline-flex items-center gap-2 rounded-pill px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-text ${levelBarColors[intensity]}`}
-                >
-                  {intensityLabels[intensity]}
-                </span>
-              </div>
-            </div>
-            <div className="flex flex-col items-end gap-2 text-right text-xs text-text-subtle">
-              <span className="rounded-pill border border-border/50 bg-bg-900/60 px-4 py-1 uppercase tracking-[0.4em]">
-                rodada viva
-              </span>
-              <span>{playerPositionLabel}</span>
-            </div>
-          </div>
-        </header>
+  const modals = (
+    <>
+      {showCreateModal && currentPlayer && (
+        <CreateCardModal
+          currentPlayer={currentPlayer}
+          intensity={intensity}
+          onAddCard={onAddCustomCard}
+          onClose={() => setShowCreateModal(false)}
+        />
+      )}
 
-        <div className="relative overflow-hidden rounded-card border border-border/60 bg-bg-900/70 p-8 shadow-heat [--focus-shadow:var(--shadow-heat)] backdrop-blur-xl">
-          <div className={`absolute inset-x-0 top-0 h-2 ${levelBarColors[intensity]}`} aria-hidden="true" />
-          <div className="pointer-events-none absolute -inset-16 bg-glow-dare opacity-30 blur-2xl" aria-hidden="true" />
-          <div className="relative z-10 space-y-8">
-            {!currentCard ? (
-              <div className="space-y-8">
-                <div className="text-center space-y-3">
-                  <span className="text-xs uppercase tracking-[0.4em] text-text-subtle">
-                    escolha sua carta
-                  </span>
-                  <h3 className="text-3xl font-display uppercase tracking-[0.18em] text-text">
-                    Verdade ou Consequência?
-                  </h3>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <button
-                    onClick={() => handleDrawCard('truth')}
-                    disabled={!currentPlayer || isDrawingPlayer}
-                    className="group flex h-[var(--button-height)] items-center justify-center gap-3 rounded-pill bg-[var(--color-primary-500)] px-6 text-lg font-semibold uppercase tracking-[0.2em] text-[var(--color-bg-900)] shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    <Heart className="h-6 w-6" />
-                    Verdade
-                  </button>
-                  <button
-                    onClick={() => handleDrawCard('dare')}
-                    disabled={!currentPlayer || isDrawingPlayer}
-                    className="group flex h-[var(--button-height)] items-center justify-center gap-3 rounded-pill bg-[var(--color-secondary-500)] px-6 text-lg font-semibold uppercase tracking-[0.2em] text-[var(--color-bg-900)] shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    <Zap className="h-6 w-6" />
-                    Desafio
-                  </button>
-                </div>
-                <p className="text-center text-sm text-text-subtle">
-                  Cada escolha muda o ritmo. Use seus boosts com sabedoria.
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold uppercase tracking-[0.3em]">
-                  <span
-                    className={`inline-flex items-center gap-2 rounded-pill px-4 py-2 shadow-heat [--focus-shadow:var(--shadow-heat)] ${
-                      currentCard.type === 'truth'
-                        ? cardTypeStyles.truth
-                        : cardTypeStyles.dare
-                    }`}
-                  >
-                    {currentCard.type === 'truth' ? <Heart size={18} /> : <Zap size={18} />}
-                    {currentCard.type === 'truth' ? 'Verdade' : 'Desafio'}
-                  </span>
-                  {currentCard.isBoosted && (
-                    <span className="inline-flex items-center gap-2 rounded-pill bg-accent-500 px-4 py-2 text-xs uppercase tracking-[0.4em] text-text shadow-heat [--focus-shadow:var(--shadow-heat)]">
-                      BOOST
-                    </span>
-                  )}
-                </div>
-                <div className="relative overflow-hidden rounded-card border border-border/50 bg-bg-800/80 p-8">
-                  <div className="absolute inset-x-6 top-0 h-1 rounded-full  bg-text/10" aria-hidden="true" />
-                  <p className="relative z-10 text-lg leading-relaxed text-text">
-                    {currentCard.text}
-                  </p>
-                  {currentCard.isCustom && (
-                    <div className="relative z-10 mt-4 inline-flex items-center gap-2 rounded-pill border border-dashed border-border/60 px-3 py-1 text-xs uppercase tracking-[0.3em] text-text-subtle">
-                      Carta personalizada
-                    </div>
-                  )}
-                </div>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <button
-                    onClick={onFulfillCard}
-                    className="flex h-14 items-center justify-center gap-2 rounded-pill bg-grad-heat px-6 text-sm font-semibold uppercase tracking-[0.2em] text-text shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110"
-                  >
-                    <CheckCircle size={20} />
-                    Cumprir
-                  </button>
-                  <button
-                    onClick={onPassCard}
-                    className="flex h-14 items-center justify-center gap-2 rounded-pill border border-border px-6 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300"
-                  >
-                    <XCircle size={20} />
-                    Passar
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
+      {showDeckModal && (
+        <DeckModal
+          cards={gameState.availableCards}
+          intensity={intensity}
+          onClose={() => setShowDeckModal(false)}
+        />
+      )}
 
-        <div className="grid gap-3 sm:grid-cols-3">
-          <button
-            onClick={() => setShowCreateModal(true)}
-            disabled={!currentPlayer}
-            className="flex h-14 items-center justify-center gap-2 rounded-pill border border-border/60 bg-bg-800/70 px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <Plus size={18} />
-            Criar carta
-          </button>
-          <button
-            onClick={() => setShowDeckModal(true)}
-            className="flex h-14 items-center justify-center gap-2 rounded-pill border border-border/60 bg-bg-800/70 px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300"
-          >
-            <Eye size={18} />
-            Baralho
-          </button>
-          <button
-            onClick={() => setShowResetConfirm(true)}
-            className="flex h-14 items-center justify-center gap-2 rounded-pill border border-secondary-500/60 bg-transparent px-4 text-sm font-semibold uppercase tracking-[0.2em] text-secondary-300 transition hover:border-secondary-500 hover:text-secondary-500"
-          >
-            <RotateCcw size={18} />
-            Reiniciar
-          </button>
-        </div>
-
-        {showCreateModal && currentPlayer && (
-          <CreateCardModal
-            currentPlayer={currentPlayer}
-            intensity={intensity}
-            onAddCard={onAddCustomCard}
-            onClose={() => setShowCreateModal(false)}
-          />
-        )}
-
-        {showDeckModal && (
-          <DeckModal
-            cards={gameState.availableCards}
-            intensity={intensity}
-            onClose={() => setShowDeckModal(false)}
-          />
-        )}
-
-        {showResetConfirm && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay-veil)] p-4">
-            <div className="w-full max-w-sm space-y-4 rounded-card border border-border/60 bg-bg-900/80 p-6 shadow-heat [--focus-shadow:var(--shadow-heat)] backdrop-blur-xl">
-              <h3 className="text-xl font-display uppercase tracking-[0.18em] text-text">
-                Reiniciar sessão?
-              </h3>
-              <p className="text-sm text-text-subtle">
-                Isso irá apagar todo o progresso e cartas criadas. Esta ação não pode ser desfeita.
-              </p>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <button
-                  onClick={() => setShowResetConfirm(false)}
-                  className="flex h-12 items-center justify-center rounded-pill border border-border px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300"
-                >
-                  Cancelar
-                </button>
-                <button
-                  onClick={() => {
-                    onResetGame();
-                    setShowResetConfirm(false);
-                  }}
-                  className="flex h-12 items-center justify-center rounded-pill bg-[var(--color-secondary-500)] px-4 text-sm font-semibold uppercase tracking-[0.2em] text-[var(--color-bg-900)] shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110"
-                >
-                  Reiniciar
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {isDrawingPlayer && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay-veil)]/95 px-4 py-6 backdrop-blur-md">
-          <div className="relative w-full max-w-md overflow-hidden rounded-card border border-border/60 bg-bg-900/85 p-8 text-center shadow-heat [--focus-shadow:var(--shadow-heat)]">
-            <div className="pointer-events-none absolute -inset-20 opacity-40" aria-hidden="true">
-              <div className="absolute inset-0 animate-spin-slower bg-grad-heat blur-3xl" />
-            </div>
-            <div className="pointer-events-none absolute inset-0 bg-[var(--texture-noise)] opacity-20 mix-blend-soft-light" aria-hidden="true" />
-            <div className="relative z-10 space-y-5">
-              <span className="inline-flex items-center gap-2 rounded-pill border border-border/40 bg-bg-800/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-text-subtle animate-shuffle-pulse">
-                Sorteando próxima rodada
-              </span>
-              <div className="min-h-[3rem] text-3xl font-display uppercase tracking-[0.18em] text-text" aria-live="polite">
-                {drawHighlightText}
-              </div>
-              <div className="flex items-center justify-center gap-2 text-xs uppercase tracking-[0.3em] text-text-subtle">
-                {finalDrawName ? (
-                  <CheckCircle className="h-4 w-4 text-accent-500" />
-                ) : (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                )}
-                <span>{drawStatusText}</span>
-              </div>
+      {showResetConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay-veil)] p-4">
+          <div className="w-full max-w-sm space-y-4 rounded-card border border-border/60 bg-bg-900/80 p-6 shadow-heat [--focus-shadow:var(--shadow-heat)] backdrop-blur-xl">
+            <h3 className="text-xl font-display uppercase tracking-[0.18em] text-text">Reiniciar sessão?</h3>
+            <p className="text-sm text-text-subtle">
+              Isso irá apagar todo o progresso e cartas criadas. Esta ação não pode ser desfeita.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <button
+                onClick={() => setShowResetConfirm(false)}
+                className="flex h-12 items-center justify-center rounded-pill border border-border px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={() => {
+                  onResetGame();
+                  setShowResetConfirm(false);
+                }}
+                className="flex h-12 items-center justify-center rounded-pill bg-[var(--color-secondary-500)] px-4 text-sm font-semibold uppercase tracking-[0.2em] text-[var(--color-bg-900)] shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110"
+              >
+                Reiniciar
+              </button>
             </div>
           </div>
         </div>
       )}
-    </div>
+    </>
+  );
+
+  const drawingOverlay =
+    isDrawingPlayer && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--overlay-veil)]/95 px-4 py-6 backdrop-blur-md">
+        <div className="relative w-full max-w-md overflow-hidden rounded-card border border-border/60 bg-bg-900/85 p-8 text-center shadow-heat [--focus-shadow:var(--shadow-heat)]">
+          <div className="pointer-events-none absolute -inset-20 opacity-40" aria-hidden="true">
+            <div className="absolute inset-0 animate-spin-slower bg-grad-heat blur-3xl" />
+          </div>
+          <div className="pointer-events-none absolute inset-0 bg-[var(--texture-noise)] opacity-20 mix-blend-soft-light" aria-hidden="true" />
+          <div className="relative z-10 space-y-5">
+            <span className="inline-flex items-center gap-2 rounded-pill border border-border/40 bg-bg-800/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-text-subtle animate-shuffle-pulse">
+              Sorteando próxima rodada
+            </span>
+            <div className="min-h-[3rem] text-3xl font-display uppercase tracking-[0.18em] text-text" aria-live="polite">
+              {drawHighlightText}
+            </div>
+            <div className="flex items-center justify-center gap-2 text-xs uppercase tracking-[0.3em] text-text-subtle">
+              {finalDrawName ? (
+                <CheckCircle className="h-4 w-4 text-accent-500" />
+              ) : (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              )}
+              <span>{drawStatusText}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+
+  if (theme === 'game') {
+    return (
+      <>
+        <div className="relative flex flex-1 flex-col">
+          <HUDHeader
+            intensity={intensity}
+            playerName={playerNameDisplay}
+            boostPoints={boostPoints}
+            turnLabel={playerPositionLabel}
+          />
+          <div className="flex flex-1 justify-center px-4 pb-32 pt-24 sm:px-6">
+            <div className="flex w-full max-w-5xl flex-1 flex-col items-center gap-6">
+              <TurnWheel
+                players={gameState.players}
+                currentPlayerId={currentPlayer?.id ?? null}
+                highlightedName={highlightedName}
+                finalDrawName={finalDrawName}
+              />
+              <div className="flex w-full flex-1 flex-col items-center justify-center gap-6 text-center">
+                {!currentCard ? (
+                  <>
+                    <span className="rounded-pill border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-text-subtle">
+                      Verdade x Desafio
+                    </span>
+                    <ChoiceButtons
+                      onTruth={() => handleDrawCard('truth')}
+                      onDare={() => handleDrawCard('dare')}
+                      disabled={!currentPlayer || isDrawingPlayer}
+                      className="w-full max-w-xl"
+                    />
+                  </>
+                ) : (
+                  <CardReveal
+                    card={currentCard}
+                    onFulfill={onFulfillCard}
+                    onPass={onPassCard}
+                    className="w-full"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+          <BottomBar
+            onCreate={() => setShowCreateModal(true)}
+            onDeck={() => setShowDeckModal(true)}
+            onReset={() => setShowResetConfirm(true)}
+            isCreateDisabled={!currentPlayer}
+            className="pb-[env(safe-area-inset-bottom,0px)]"
+          />
+          {modals}
+        </div>
+        {drawingOverlay}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-1 justify-center px-4 py-10 sm:px-6 lg:px-8">
+        <div className="w-full max-w-5xl space-y-8">
+          <header className="rounded-card border border-border/60 bg-bg-800/80 p-6 shadow-heat [--focus-shadow:var(--shadow-heat)] backdrop-blur-xl">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-3">
+                <span className="text-xs font-semibold uppercase tracking-[0.4em] text-text-subtle">
+                  Vez de jogar
+                </span>
+                <h2 className="text-4xl sm:text-5xl font-display uppercase tracking-[0.18em] text-text">
+                  {playerNameDisplay}
+                </h2>
+                <div className="flex flex-wrap items-center gap-3 text-sm text-text-subtle">
+                  <span className="inline-flex items-center gap-2 rounded-pill border border-border/50 bg-bg-900/60 px-4 py-1">
+                    <Zap size={16} />
+                    {playerBoostLabel}
+                  </span>
+                  <span
+                    className={`inline-flex items-center gap-2 rounded-pill px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-text ${levelBarColors[intensity]}`}
+                  >
+                    {intensityLabels[intensity]}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-2 text-right text-xs text-text-subtle">
+                <span className="rounded-pill border border-border/50 bg-bg-900/60 px-4 py-1 uppercase tracking-[0.4em]">
+                  rodada viva
+                </span>
+                <span>{playerPositionLabel}</span>
+              </div>
+            </div>
+          </header>
+
+          <div className="relative overflow-hidden rounded-card border border-border/60 bg-bg-900/70 p-8 shadow-heat [--focus-shadow:var(--shadow-heat)] backdrop-blur-xl">
+            <div className={`absolute inset-x-0 top-0 h-2 ${levelBarColors[intensity]}`} aria-hidden="true" />
+            <div className="pointer-events-none absolute -inset-16 bg-glow-dare opacity-30 blur-2xl" aria-hidden="true" />
+            <div className="relative z-10 space-y-8">
+              {!currentCard ? (
+                <div className="space-y-8">
+                  <div className="text-center space-y-3">
+                    <span className="text-xs uppercase tracking-[0.4em] text-text-subtle">
+                      escolha sua carta
+                    </span>
+                    <h3 className="text-3xl font-display uppercase tracking-[0.18em] text-text">
+                      Verdade ou Consequência?
+                    </h3>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <button
+                      onClick={() => handleDrawCard('truth')}
+                      disabled={!currentPlayer || isDrawingPlayer}
+                      className="group flex h-[var(--button-height)] items-center justify-center gap-3 rounded-pill bg-[var(--color-primary-500)] px-6 text-lg font-semibold uppercase tracking-[0.2em] text-[var(--color-bg-900)] shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Heart className="h-6 w-6" />
+                      Verdade
+                    </button>
+                    <button
+                      onClick={() => handleDrawCard('dare')}
+                      disabled={!currentPlayer || isDrawingPlayer}
+                      className="group flex h-[var(--button-height)] items-center justify-center gap-3 rounded-pill bg-[var(--color-secondary-500)] px-6 text-lg font-semibold uppercase tracking-[0.2em] text-[var(--color-bg-900)] shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Zap className="h-6 w-6" />
+                      Desafio
+                    </button>
+                  </div>
+                  <p className="text-center text-sm text-text-subtle">
+                    Cada escolha muda o ritmo. Use seus boosts com sabedoria.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-center gap-3 text-sm font-semibold uppercase tracking-[0.3em]">
+                    <span
+                      className={`inline-flex items-center gap-2 rounded-pill px-4 py-2 shadow-heat [--focus-shadow:var(--shadow-heat)] ${
+                        currentCard.type === 'truth'
+                          ? cardTypeStyles.truth
+                          : cardTypeStyles.dare
+                      }`}
+                    >
+                      {currentCard.type === 'truth' ? <Heart size={18} /> : <Zap size={18} />}
+                      {currentCard.type === 'truth' ? 'Verdade' : 'Desafio'}
+                    </span>
+                    {currentCard.isBoosted && (
+                      <span className="inline-flex items-center gap-2 rounded-pill bg-accent-500 px-4 py-2 text-xs uppercase tracking-[0.4em] text-text shadow-heat [--focus-shadow:var(--shadow-heat)]">
+                        BOOST
+                      </span>
+                    )}
+                  </div>
+                  <div className="relative overflow-hidden rounded-card border border-border/50 bg-bg-800/80 p-8">
+                    <div className="absolute inset-x-6 top-0 h-1 rounded-full  bg-text/10" aria-hidden="true" />
+                    <p className="relative z-10 text-lg leading-relaxed text-text">
+                      {currentCard.text}
+                    </p>
+                    {currentCard.isCustom && (
+                      <div className="relative z-10 mt-4 inline-flex items-center gap-2 rounded-pill border border-dashed border-border/60 px-3 py-1 text-xs uppercase tracking-[0.3em] text-text-subtle">
+                        Carta personalizada
+                      </div>
+                    )}
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <button
+                      onClick={onFulfillCard}
+                      className="flex h-14 items-center justify-center gap-2 rounded-pill bg-grad-heat px-6 text-sm font-semibold uppercase tracking-[0.2em] text-text shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110"
+                    >
+                      <CheckCircle size={20} />
+                      Cumprir
+                    </button>
+                    <button
+                      onClick={onPassCard}
+                      className="flex h-14 items-center justify-center gap-2 rounded-pill border border-border px-6 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300"
+                    >
+                      <XCircle size={20} />
+                      Passar
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <button
+              onClick={() => setShowCreateModal(true)}
+              disabled={!currentPlayer}
+              className="flex h-14 items-center justify-center gap-2 rounded-pill border border-border/60 bg-bg-800/70 px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Plus size={18} />
+              Criar carta
+            </button>
+            <button
+              onClick={() => setShowDeckModal(true)}
+              className="flex h-14 items-center justify-center gap-2 rounded-pill border border-border/60 bg-bg-800/70 px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text transition hover:border-primary-500 hover:text-primary-300"
+            >
+              <Eye size={18} />
+              Baralho
+            </button>
+            <button
+              onClick={() => setShowResetConfirm(true)}
+              className="flex h-14 items-center justify-center gap-2 rounded-pill border border-secondary-500/60 bg-transparent px-4 text-sm font-semibold uppercase tracking-[0.2em] text-secondary-300 transition hover:border-secondary-500 hover:text-secondary-500"
+            >
+              <RotateCcw size={18} />
+              Reiniciar
+            </button>
+          </div>
+
+          {modals}
+        </div>
+      </div>
+      {drawingOverlay}
+    </>
   );
 };

--- a/src/hooks/useGameTheme.ts
+++ b/src/hooks/useGameTheme.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+type GameTheme = 'classic' | 'game';
+
+export function useGameTheme(): GameTheme {
+  const theme = useMemo<GameTheme>(() => {
+    if (typeof window === 'undefined') {
+      return 'classic';
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    return params.get('theme') === 'game' ? 'game' : 'classic';
+  }, []);
+
+  return theme;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -56,7 +56,49 @@
   }
 }
 
+@layer components {
+  .interactive-press {
+    transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+  }
+
+  .interactive-press:hover,
+  .interactive-press:focus-visible {
+    transform: scale(1.02);
+    box-shadow: 0 12px 32px rgba(255, 46, 126, 0.35);
+  }
+
+  .interactive-press:active {
+    transform: scale(0.98);
+    box-shadow: 0 10px 26px rgba(255, 46, 126, 0.3);
+  }
+}
+
 @layer utilities {
+  @keyframes cardReveal {
+    0% {
+      opacity: 0;
+      transform: translateY(8px) rotateX(6deg);
+      filter: blur(4px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0) rotateX(0deg);
+      filter: blur(0);
+    }
+  }
+
+  @keyframes boostFlash {
+    0% {
+      box-shadow: 0 0 0 0 rgba(196, 0, 255, 0);
+    }
+    45% {
+      box-shadow: 0 0 0 4px rgba(196, 0, 255, 0.45);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(196, 0, 255, 0);
+    }
+  }
+
   @keyframes shufflePulse {
     0%,
     100% {
@@ -84,5 +126,14 @@
 
   .animate-spin-slower {
     animation: spinSlower 14s linear infinite;
+  }
+
+  .animate-card-reveal {
+    animation: cardReveal 160ms ease-out forwards;
+    transform-origin: center top;
+  }
+
+  .animate-boost-flash {
+    animation: boostFlash 540ms ease-out;
   }
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,30 +1,37 @@
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Plus+Jakarta+Sans:wght@400;600;700&display=swap');
+
 :root {
-  --color-primary-300: #FF6AA6;
-  --color-primary-500: #FF2E7E;
-  --color-primary-700: #D11663;
+  --color-primary-300: #ff6aa6;
+  --color-primary-500: #ff2e7e;
+  --color-primary-700: #d11663;
 
-  --color-secondary-300: #FF927C;
-  --color-secondary-500: #FF6B4A;
-  --color-secondary-700: #D94C2E;
+  --color-secondary-300: #ff927c;
+  --color-secondary-500: #ff6b4a;
+  --color-secondary-700: #d94c2e;
 
-  --color-accent-500: #C400FF;
+  --color-accent-500: #c400ff;
 
-  --color-bg-900: #0B0B12;
+  --color-bg-900: #0b0b12;
   --color-bg-800: #141420;
-  --color-bg-700: #1C1C2C;
+  --color-bg-700: #1c1c2c;
 
-  --color-text: #FFFFFF;
-  --color-text-2: #B8B8C9;
-  --color-border: #2A2A3A;
+  --color-text: #ffffff;
+  --color-text-2: #b8b8c9;
+  --color-border: #2a2a3a;
 
-  --level-leve: #FF6AA6;
-  --level-medio: #FF2E7E;
-  --level-pesado: #D94C2E;
-  --level-extremo: #C400FF;
+  --level-leve: #ff6aa6;
+  --level-medio: #ff2e7e;
+  --level-pesado: #d94c2e;
+  --level-extremo: #c400ff;
 
-  --grad-heat: linear-gradient(135deg, #FF2E7E 0%, #FF6B4A 50%, #C400FF 100%);
-  --glow-dare: radial-gradient(closest-side, rgba(255, 46, 126, 0.65), transparent 70%);
-  --grad-overlay: radial-gradient(120% 120% at 50% 0%, rgba(196, 0, 255, 0.18) 0%, rgba(255, 107, 74, 0.12) 45%, transparent 85%);
+  --grad-heat: linear-gradient(135deg, #ff2e7e 0%, #ff6b4a 50%, #c400ff 100%);
+  --glow-dare: radial-gradient(closest-side, #ff2e7e, transparent 70%);
+  --grad-overlay: radial-gradient(
+    120% 120% at 50% 0%,
+    rgba(196, 0, 255, 0.18) 0%,
+    rgba(255, 107, 74, 0.12) 45%,
+    transparent 85%
+  );
 
   --font-display: 'Bebas Neue', sans-serif;
   --font-body: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/src/ui/BoostBadge.tsx
+++ b/src/ui/BoostBadge.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface BoostBadgeProps {
+  className?: string;
+}
+
+export const BoostBadge: React.FC<BoostBadgeProps> = ({ className = '' }) => {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-pill bg-accent-500 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-text shadow-heat ${className}`.trim()}
+    >
+      BOOST
+    </span>
+  );
+};

--- a/src/ui/BottomBar.tsx
+++ b/src/ui/BottomBar.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+interface BottomBarProps {
+  onCreate: () => void;
+  onDeck: () => void;
+  onReset: () => void;
+  isCreateDisabled?: boolean;
+  className?: string;
+}
+
+const actions = [
+  { key: 'create', label: 'Criar', icon: '✚' },
+  { key: 'deck', label: 'Baralho', icon: '🃏' },
+  { key: 'reset', label: 'Reset', icon: '⟲' },
+] as const;
+
+export const BottomBar: React.FC<BottomBarProps> = ({
+  onCreate,
+  onDeck,
+  onReset,
+  isCreateDisabled = false,
+  className = '',
+}) => {
+  const handleAction = (key: (typeof actions)[number]['key']) => {
+    switch (key) {
+      case 'create':
+        if (!isCreateDisabled) {
+          onCreate();
+        }
+        break;
+      case 'deck':
+        onDeck();
+        break;
+      case 'reset':
+        onReset();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <nav
+      className={`pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center ${className}`.trim()}
+      aria-label="Ações do jogo"
+    >
+      <div className="pointer-events-auto mb-4 w-[calc(100%-1.5rem)] max-w-lg rounded-pill border border-white/10 bg-bg-900/90 px-4 py-3 shadow-heat backdrop-blur-xl">
+        <div className="grid grid-cols-3 gap-3 text-center text-xs font-semibold uppercase tracking-[0.35em] text-text">
+          {actions.map((action) => {
+            const isDisabled = action.key === 'create' && isCreateDisabled;
+
+            return (
+              <button
+                key={action.key}
+                type="button"
+                onClick={() => handleAction(action.key)}
+                disabled={isDisabled}
+                className={`interactive-press flex h-16 flex-col items-center justify-center gap-1 rounded-pill border border-white/10 bg-white/5 text-text transition disabled:cursor-not-allowed disabled:opacity-40`}
+              >
+                <span className="text-xl" aria-hidden="true">
+                  {action.icon}
+                </span>
+                {action.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+};

--- a/src/ui/BrandMark.tsx
+++ b/src/ui/BrandMark.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface BrandMarkProps {
+  className?: string;
+}
+
+export const BrandMark: React.FC<BrandMarkProps> = ({ className = '' }) => {
+  return (
+    <div
+      className={`flex h-12 w-12 items-center justify-center rounded-pill bg-grad-heat text-lg font-display uppercase tracking-[0.4em] text-[var(--color-bg-900)] shadow-heat ${className}`.trim()}
+      aria-label="Verdade ou Consequência"
+    >
+      VC
+    </div>
+  );
+};

--- a/src/ui/CardReveal.tsx
+++ b/src/ui/CardReveal.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Card, IntensityLevel } from '../types/game';
+import { BoostBadge } from './BoostBadge';
+import { Heart, Zap, Check, X } from 'lucide-react';
+
+interface CardRevealProps {
+  card: Card;
+  onFulfill: () => void;
+  onPass: () => void;
+  className?: string;
+}
+
+const levelBarColor: Record<IntensityLevel, string> = {
+  leve: 'bg-level-leve',
+  medio: 'bg-level-medio',
+  pesado: 'bg-level-pesado',
+  extremo: 'bg-level-extremo',
+};
+
+export const CardReveal: React.FC<CardRevealProps> = ({ card, onFulfill, onPass, className = '' }) => {
+  return (
+    <section
+      className={`relative w-full max-w-xl rounded-card border border-white/10 bg-bg-800/70 p-6 shadow-heat backdrop-blur-xl ${className}`.trim()}
+      aria-live="polite"
+    >
+      <div className={`absolute inset-x-4 top-3 h-1 rounded-full ${levelBarColor[card.level]}`} aria-hidden="true" />
+      <div
+        className={`relative mt-6 flex flex-col gap-6 rounded-card border border-white/10 bg-bg-900/70 p-6 ${
+          card.isBoosted ? 'animate-boost-flash' : ''
+        }`}
+      >
+        <header className="flex items-center justify-between text-xs uppercase tracking-[0.4em] text-text-subtle">
+          <span className="inline-flex items-center gap-2 rounded-pill bg-white/5 px-3 py-1 text-text">
+            {card.type === 'truth' ? (
+              <Heart className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <Zap className="h-4 w-4" aria-hidden="true" />
+            )}
+            {card.type === 'truth' ? 'Verdade' : 'Desafio'}
+          </span>
+          <span className="rounded-pill border border-white/10 px-3 py-1">Carta</span>
+        </header>
+        <p className="min-h-[6rem] text-lg font-medium leading-relaxed text-text animate-card-reveal">
+          {card.text}
+        </p>
+        <div className="flex flex-wrap items-center gap-2 text-[0.65rem] uppercase tracking-[0.35em] text-text-subtle">
+          {card.isCustom && <span className="rounded-pill border border-dashed border-white/20 px-3 py-1">Custom</span>}
+          {card.isBoosted && <BoostBadge />}
+        </div>
+      </div>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={onFulfill}
+          className="interactive-press flex h-14 items-center justify-center gap-2 rounded-pill bg-grad-heat px-6 text-sm font-semibold uppercase tracking-[0.25em] text-text shadow-heat"
+        >
+          <Check className="h-5 w-5" aria-hidden="true" />
+          Cumprir
+        </button>
+        <button
+          type="button"
+          onClick={onPass}
+          className="interactive-press flex h-14 items-center justify-center gap-2 rounded-pill border border-white/15 px-6 text-sm font-semibold uppercase tracking-[0.25em] text-text"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+          Passar
+        </button>
+      </div>
+    </section>
+  );
+};

--- a/src/ui/ChoiceButtons.tsx
+++ b/src/ui/ChoiceButtons.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { MessageCircle, Zap } from 'lucide-react';
+
+interface ChoiceButtonsProps {
+  onTruth: () => void;
+  onDare: () => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const ChoiceButtons: React.FC<ChoiceButtonsProps> = ({
+  onTruth,
+  onDare,
+  disabled = false,
+  className = '',
+}) => {
+  return (
+    <div className={`flex w-full flex-col items-center gap-4 sm:flex-row ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={onTruth}
+        disabled={disabled}
+        className="interactive-press flex h-20 w-full items-center justify-center gap-3 rounded-pill bg-grad-heat px-6 text-lg font-semibold uppercase tracking-[0.25em] text-[var(--color-bg-900)] shadow-heat transition disabled:cursor-not-allowed disabled:opacity-40"
+        aria-label="Puxar carta de verdade"
+      >
+        <MessageCircle className="h-6 w-6" aria-hidden="true" />
+        Verdade
+      </button>
+      <button
+        type="button"
+        onClick={onDare}
+        disabled={disabled}
+        className="interactive-press flex h-20 w-full items-center justify-center gap-3 rounded-pill bg-[var(--color-secondary-500)] px-6 text-lg font-semibold uppercase tracking-[0.25em] text-[var(--color-bg-900)] shadow-heat transition disabled:cursor-not-allowed disabled:opacity-40"
+        aria-label="Puxar carta de desafio"
+      >
+        <Zap className="h-6 w-6" aria-hidden="true" />
+        Desafio
+      </button>
+    </div>
+  );
+};

--- a/src/ui/HUDHeader.tsx
+++ b/src/ui/HUDHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+import { IntensityLevel } from '../types/game';
+import { BrandMark } from './BrandMark';
+import { BoostBadge } from './BoostBadge';
+
+interface HUDHeaderProps {
+  intensity: IntensityLevel;
+  playerName: string;
+  boostPoints: number;
+  turnLabel: string;
+  className?: string;
+}
+
+const intensityLabels: Record<IntensityLevel, string> = {
+  leve: 'Leve',
+  medio: 'Médio',
+  pesado: 'Pesado',
+  extremo: 'Extremo',
+};
+
+const intensityBackground: Record<IntensityLevel, string> = {
+  leve: 'rgba(255, 106, 166, 0.2)',
+  medio: 'rgba(255, 46, 126, 0.2)',
+  pesado: 'rgba(217, 76, 46, 0.2)',
+  extremo: 'rgba(196, 0, 255, 0.2)',
+};
+
+export const HUDHeader: React.FC<HUDHeaderProps> = ({
+  intensity,
+  playerName,
+  boostPoints,
+  turnLabel,
+  className = '',
+}) => {
+  return (
+    <header
+      className={`pointer-events-none fixed left-1/2 top-4 z-40 w-[calc(100%-1.5rem)] max-w-3xl -translate-x-1/2 ${className}`.trim()}
+      aria-label="Painel do turno"
+    >
+      <div className="pointer-events-auto flex items-center justify-between gap-4 rounded-pill border border-white/10 bg-white/8 px-4 py-3 text-xs uppercase tracking-[0.35em] text-text backdrop-blur-xl">
+        <div className="flex items-center gap-4">
+          <BrandMark className="h-11 w-11 text-[var(--color-bg-900)]" />
+          <div className="leading-none">
+            <span className="block text-[0.6rem] text-text-subtle">Vez de</span>
+            <span className="text-2xl font-display uppercase tracking-[0.2em] text-text">{playerName}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-[0.55rem]">
+          <span
+            className="flex items-center gap-2 rounded-pill px-3 py-1 text-text"
+            style={{ backgroundColor: intensityBackground[intensity] }}
+          >
+            <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+            {intensityLabels[intensity]}
+          </span>
+          <div className="flex items-center gap-2">
+            <BoostBadge className="text-[0.55rem]" />
+            <span className="text-text-subtle tracking-[0.3em]">+{boostPoints}</span>
+          </div>
+          <span className="hidden rounded-pill border border-white/10 px-3 py-1 text-text-subtle sm:inline-flex">
+            {turnLabel}
+          </span>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/ui/TurnWheel.tsx
+++ b/src/ui/TurnWheel.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Player } from '../types/game';
+
+interface TurnWheelProps {
+  players: Player[];
+  currentPlayerId: string | null;
+  highlightedName?: string | null;
+  finalDrawName?: string | null;
+  className?: string;
+}
+
+const getInitial = (name: string) => name.charAt(0).toUpperCase();
+
+export const TurnWheel: React.FC<TurnWheelProps> = ({
+  players,
+  currentPlayerId,
+  highlightedName,
+  finalDrawName,
+  className = '',
+}) => {
+  const activeName = currentPlayerId
+    ? players.find((player) => player.id === currentPlayerId)?.name ?? null
+    : finalDrawName ?? highlightedName ?? null;
+
+  return (
+    <div
+      className={`w-full overflow-hidden ${className}`.trim()}
+      aria-label="Fila de jogadores"
+    >
+      <div className="flex w-full gap-3 overflow-x-auto px-2 py-3" role="list">
+        {players.map((player) => {
+          const isActive = currentPlayerId
+            ? player.id === currentPlayerId
+            : player.name === activeName;
+
+          return (
+            <div
+              key={player.id}
+              role="listitem"
+              aria-current={isActive ? 'true' : undefined}
+              className={`flex min-w-[5.25rem] flex-col items-center gap-2 rounded-card border px-3 py-2 text-center transition ${
+                isActive
+                  ? 'border-accent-500 bg-accent-500/20 text-text'
+                  : 'border-white/5 bg-white/5 text-text-subtle'
+              }`}
+            >
+              <div
+                className={`flex h-12 w-12 items-center justify-center rounded-full text-base font-semibold uppercase ${
+                  isActive ? 'bg-grad-heat text-[var(--color-bg-900)] shadow-heat' : 'bg-white/10 text-text'
+                }`}
+              >
+                {getInitial(player.name)}
+              </div>
+              <span className="text-[0.7rem] font-semibold uppercase tracking-[0.3em]">
+                {player.name}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a theme toggle so `?theme=game` activates the arcade UI while preserving the classic layout by default
- introduce reusable HUD, wheel, button, card, and bottom bar components styled with the new neon game look and motion tokens
- update the game screen composition to wire the new components without touching existing game logic

## Testing
- npm run build
- npm run lint *(fails: existing unused variable in SetupScreen.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d4442e4d988326b7f20d72861bb2b9